### PR TITLE
Add groupBy [WIP]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
   ],
   "dependencies": {
     "purescript-control": "^4.0.0",
-    "purescript-profunctor": "^4.0.0"
+    "purescript-profunctor": "^4.0.0",
+    "purescript-ordered-collections": "^1.6.0"
   },
   "devDependencies": {
     "purescript-console": "^4.0.0",

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,7 +1,7 @@
 {
     "name": "folds",
     "source": "https://github.com/purescript/package-sets.git",
-    "set": "psc-0.10.1",
+    "set": "psc-0.12.3-20190312",
     "depends": [
       "bifunctors",
       "control",
@@ -11,8 +11,8 @@
       "identity",
       "invariant",
       "maybe",
-      "monoid",
       "newtype",
+      "ordered-collections",
       "prelude",
       "profunctor",
       "tuples"

--- a/src/Control/Fold.purs
+++ b/src/Control/Fold.purs
@@ -53,7 +53,8 @@ import Data.Distributive (class Distributive, cotraverse)
 import Data.Foldable (class Foldable)
 import Data.Function (applyFlipped)
 import Data.HeytingAlgebra (ff, tt)
-import Data.Maybe (Maybe(..))
+import Data.Map (Map, alter)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Monoid (class Monoid, mempty)
 import Data.Profunctor (class Profunctor, dimap, lcmap)
 import Data.Profunctor.Closed (class Closed, closed)
@@ -164,6 +165,14 @@ elem a = any (_ == a)
 -- | A `Fold` which tests if a specific value did not appear as an input.
 notElem :: forall a. Eq a => a -> Fold a Boolean
 notElem a = all (_ /= a)
+
+-- | Perform a `Fold` while grouping the data according to a specified
+-- | group projection function. Returns the folded result grouped as a
+-- | map keyed by the group.
+groupBy :: forall a r g . Ord g => (a -> g) -> Fold a r -> Fold a (Map g r)
+groupBy grouper f1 = unfoldFold mempty combine (map extract)
+  where
+    combine m x = alter (pure <<< stepFold x <<< fromMaybe f1) (grouper x) m
 
 instance profunctorFold :: Profunctor Fold where
   dimap f g (Fold o) = Fold { step, finish }


### PR DESCRIPTION
This adds a translation of the `groupBy` combinator from Control.Foldl.

Submitting this for discussion, since perhaps you prefer to avoid the `ordered-collections` dependency this introduces, or to keep things compatible with older Purescript versions?

Similarly, I've been finding the following Fold useful, but I've held off on adding it to this PR:
```purescript
flattenWithIndex :: forall a g r b fi . FoldableWithIndex g fi => Monoid b => (g -> r -> b) -> Fold a (fi r) -> Fold a b
flattenWithIndex = map <<< foldMapWithIndex
```